### PR TITLE
Fix execution guard in stackdash_menu

### DIFF
--- a/stackdash_menu.py
+++ b/stackdash_menu.py
@@ -1324,4 +1324,5 @@ def oauthcompose():
     oauthcompose = subprocess.run('sudo docker-compose -f /opt/stackdash/docker-appdata/traefik/docker-compose.yml up -d', shell=True)
     print ("*** Traefik is deployed! ***")
                                                                      
-main()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- avoid executing `main()` when `stackdash_menu.py` is imported

## Testing
- `python3 -m py_compile stackdash_menu.py`


------
https://chatgpt.com/codex/tasks/task_e_684509ccf13883219b7339e7fe8a14d2